### PR TITLE
Handle case when mGet returns false on empty array

### DIFF
--- a/src/Drivers/Redis.php
+++ b/src/Drivers/Redis.php
@@ -170,7 +170,13 @@ class Redis extends Common
         $now    = time();
 
         foreach (array_keys($this->connectionsOptions) as $key) {
-            foreach ($this->getRedisObject($key)->mGet($identifiers) as $i => $row) {
+            $mGetResult = $this->getRedisObject($key)->mGet($identifiers);
+
+            if ($mGetResult === false) {
+                continue;
+            }
+
+            foreach ($mGetResult as $i => $row) {
                 if (empty($row)) {
                     continue;
                 }


### PR DESCRIPTION
mGet([]) return false

Which cause 
Warning: Invalid argument supplied for foreach() in /var/www/vendor/endeveit/cache/src/Drivers/Redis.php on line 173