### PR TITLE
Update Memcached::doSave() so that its signature matches parent class

### DIFF
--- a/src/Drivers/Memcached.php
+++ b/src/Drivers/Memcached.php
@@ -95,7 +95,7 @@ class Memcached extends Memcache
      * @param  array   $tags
      * @return boolean
      */
-    protected function doSave($data, $id, array $tags = array())
+    protected function doSave($data, $id, array $tags = array(), $lifetime = false)
     {
         $this->validateIdentifier($id);
 


### PR DESCRIPTION
I found that this was needed for PHP 7 compatibility.